### PR TITLE
[WIP] Allow user styling and retry upload

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-uploader.html
+++ b/examples/vanilla-ts-esm/public/mux-uploader.html
@@ -10,7 +10,6 @@
         flex-direction: column;
         align-items: flex-start;
         font-family: Arial;
-        background-color: #f5f5f4;
       }
 
       .direct-upload-url {
@@ -20,14 +19,21 @@
       }
       
       mux-uploader {
-        /* text-align: center;
-        border: 1px solid black; */
         width: 100%;
         margin: 40px auto;
         display: block;
         padding-bottom: 150px;
         max-width: 400px;
         padding: 40px;
+
+        /* --uploader-background-color: #f5f5f4;
+
+        --progress-bar-fill-color: purple;
+        --progress-radial-fill-color: pink;
+        --button-background-color: rgb(233, 178, 75);
+        --button-hover-background: rgb(221, 208, 208);
+        --button-hover-text: black; */
+        --button-border-radius: 40px;
       }
      
       mux-uploader[upload-in-progress] {


### PR DESCRIPTION
## Description

Adds WIP code for the following:
- CSS variables to allow users to style font, background, button and progress bar(s)
- Clean up some logic and variables
- Complete UI clean up when user retries

## New To-Dos / Unknowns
- User cannot reattempt uploading the same file when clicking the file picker but they can do it on drag and drop
  - It seems like `FileList` does not allow us to change an indexed property
  - Theorized they just had opinions on how and tried to make a setter but it also doesn't like that

## Work Left
- Make progress bar status (upload percentage, error, completion) be read by screen reader
- Allowing the use of a full-page mask like stream.new
- Allowing the use of full-page drag and drop zone like stream.new

## Screen Recording
https://www.loom.com/share/1a7b39e86c924392ba753aa062817355
