### PR TITLE
[WIP] Full-screen use case i.e. stream.new

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-uploader.html
+++ b/examples/vanilla-ts-esm/public/mux-uploader.html
@@ -6,29 +6,106 @@
     <script type="module" src="./dist/mux-uploader.js"></script>
     <style>
       body {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        font-family: Arial;
+        margin: 0;
+        background: #f8f8f8;
       }
 
       .direct-upload-url {
         padding: 8px 12px;
         width: 400px;
-        max-width: 100%;
+      }
+
+      .container {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        font-family: Arial;
+        height: 90vh;
+      }
+
+      header {
+        margin-bottom: 100px;
+        z-index: 10;
+        position: relative;
+      }
+
+      header > h1 {
+        font-size: 5vw;
+        line-height: 6vw;
+        text-align: left;
+        max-width: 45vw;
+        z-index: 10;
+        position: relative;
+      }
+
+      h2 {
+        font-size: 3vw;
+        line-height: 4vw;
+        text-align: left;
+        max-width: 45vw;
+        z-index: 10;
+        position: relative;
+      }
+
+      input {
+        max-width: 45vw;
+        margin-bottom: 50px;
+        z-index: 10;
+        position: relative;
+      }
+
+      main {
+        box-sizing: border-box;
+        padding: 20px;
+        height: 100%;
+        width: 100%;
+      }
+
+      .upload-widget {
+        margin-top: 50px;
+        text-align: center;
+        padding: 30px;
+        border: 1px grey solid;
+        border-radius: 4px;
+        box-shadow: 2px 4px #888888;
+      }
+
+      .button-container {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+
+        /* position: absolute;
+        right: 0;
+        bottom: 0;
+
+        margin-top: 30px;
+        margin-right: 30px;
+        margin-bottom: 100px; */
+      }
+
+      .second-button {
+        align-self: flex-end;
+        margin-top: 20px;
+        z-index: 10;
+        position: relative;
+        /* width: 15%; */
+      }
+
+      footer {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 20px;
+        z-index: 10;
+        position: relative;
       }
       
       mux-uploader {
-        width: 100%;
-        margin: 40px auto;
-        display: block;
-        padding-bottom: 150px;
-        max-width: 400px;
-        padding: 40px;
+        /* --uploader-background-color: rgb(196, 196, 196, 0.95); */
+        align-self: flex-end;
 
-        /* --uploader-background-color: #f5f5f4;
-
-        --progress-bar-fill-color: purple;
+        /* --progress-bar-fill-color: purple;
         --progress-radial-fill-color: pink;
         --button-background-color: rgb(233, 178, 75);
         --button-hover-background: rgb(221, 208, 208);
@@ -43,13 +120,30 @@
     </style>
   </head>
   <body>
-    <h1>Enter your upload GCS url:</h1>
-    <input type="text" class="direct-upload-url" placeholder="https://storage.googleapis.com/..." />
-    <mux-uploader type="bar" draggable>
-      <!-- <button type="button" slot="custom-button">Custom button</button> -->
-      <!-- <p slot="custom-progress">Uploading...</p> -->
-    </mux-uploader>
-    <a href="../">Browse Elements</a>
+    <div class="container">
+      <main>
+          <header>
+            <h1>Add a video.</h1>
+            <h1>Get a shareable link to stream it.</h1>
+          </header>
+          <h2>Enter your upload GCS url:</h1>
+          <input type="text" class="direct-upload-url" placeholder="https://storage.googleapis.com/..." />
+          <!-- <div class="upload-widget"> -->
+            <!-- <mux-uploader type="bar" draggable> -->
+              <!-- <button type="button" slot="custom-button">Custom button</button> -->
+              <!-- <p slot="custom-progress">Uploading...</p> -->
+            <!-- </mux-uploader> -->
+          <!-- </div> -->
+          <div class="button-container">
+            <mux-uploader type="bar" draggable>
+              <!-- <button type="button" slot="custom-button">Custom button</button> -->
+              <!-- <p slot="custom-progress">Uploading...</p> -->
+            </mux-uploader>
+            <button class="second-button">Some other sample button</button>
+          </div>
+      </main>
+    </div>
+    <footer><a href="../">Browse Elements</a></footer>
 
     <script>
       const input = document.querySelector('input[type="text"]');

--- a/examples/vanilla-ts-esm/public/mux-uploader.html
+++ b/examples/vanilla-ts-esm/public/mux-uploader.html
@@ -26,8 +26,6 @@
 
       header {
         margin-bottom: 100px;
-        z-index: 10;
-        position: relative;
       }
 
       header > h1 {

--- a/examples/vanilla-ts-esm/public/mux-uploader.html
+++ b/examples/vanilla-ts-esm/public/mux-uploader.html
@@ -60,15 +60,6 @@
         width: 100%;
       }
 
-      .upload-widget {
-        margin-top: 50px;
-        text-align: center;
-        padding: 30px;
-        border: 1px grey solid;
-        border-radius: 4px;
-        box-shadow: 2px 4px #888888;
-      }
-
       .button-container {
         box-sizing: border-box;
         display: flex;
@@ -126,12 +117,6 @@
           </header>
           <h2>Enter your upload GCS url:</h1>
           <input type="text" class="direct-upload-url" placeholder="https://storage.googleapis.com/..." />
-          <!-- <div class="upload-widget"> -->
-            <!-- <mux-uploader type="bar" draggable> -->
-              <!-- <button type="button" slot="custom-button">Custom button</button> -->
-              <!-- <p slot="custom-progress">Uploading...</p> -->
-            <!-- </mux-uploader> -->
-          <!-- </div> -->
           <div class="button-container">
             <mux-uploader type="bar" draggable>
               <!-- <button type="button" slot="custom-button">Custom button</button> -->

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -431,6 +431,11 @@ class MuxUploaderElement extends HTMLElement {
       if (this.statusMessage) this.statusMessage.innerHTML = '';
     }
 
+    if (this.overlay) {
+      this.overlay.style.zIndex = '-1';
+      this.overlay.style.backgroundColor = '';
+    }
+
     // Clear previous error message if an upload is reattempted
     if (this.statusMessage) {
       this.removeAttribute('upload-error');

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -101,9 +101,9 @@ button:active {
   position: relative;
 }
 
-:host([drag-active]) {
+/*:host([drag-active]) {
   background: #cbd5e1;
-}
+}*/
 
 :host([type="radial"][upload-in-progress]) .radial-type {
   display: block;
@@ -368,7 +368,8 @@ class MuxUploaderElement extends HTMLElement {
         }
         evt.preventDefault();
         evt.stopPropagation();
-        this.setAttribute('drag-active', '');
+        // TO-DO: Instead of setting styles every where, consider the below.
+        // this.setAttribute('drag-active', '');
       });
 
       this.addEventListener('dragleave', (evt) => {
@@ -425,6 +426,10 @@ class MuxUploaderElement extends HTMLElement {
     const url = this.getAttribute('url');
 
     if (!url) {
+      if (this.overlay) {
+        this.overlay.style.zIndex = '-1';
+        this.overlay.style.backgroundColor = '';
+      }
       if (this.statusMessage) this.statusMessage.innerHTML = 'No url attribute specified -- cannot handleUpload';
       throw Error('No url attribute specified -- cannot handleUpload');
     } else {

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -7,8 +7,18 @@ const styles = `
   background-color: var(--uploader-background-color, inherit);
 }
 
+.overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  z-index: -1;
+}
+
 .dropzone {
-  background-color: rgba(226, 253, 255, 0.95);
   position: absolute;
   top: 0;
   bottom: 0;
@@ -224,6 +234,7 @@ template.innerHTML = `
 </div>
 
 <div class="dropzone" id="dropzone"></div>
+<div class="overlay" id="overlay"></div>
 `;
 
 const TYPES = {
@@ -240,6 +251,7 @@ class MuxUploaderElement extends HTMLElement {
   statusMessage: HTMLElement | null | undefined;
   retryMessage: HTMLElement | null | undefined;
   dropzone: HTMLElement | null | undefined;
+  overlay: HTMLElement | null | undefined;
 
   constructor() {
     super();
@@ -256,6 +268,7 @@ class MuxUploaderElement extends HTMLElement {
     this.statusMessage = this.shadowRoot?.getElementById('status-message');
     this.retryMessage = this.shadowRoot?.getElementById('retry-message');
     this.dropzone = this.shadowRoot?.getElementById('dropzone');
+    this.overlay = this.shadowRoot?.getElementById('overlay');
   }
 
   connectedCallback() {
@@ -349,6 +362,10 @@ class MuxUploaderElement extends HTMLElement {
     if (this.dropzone) {
       this.addEventListener('dragenter', (evt) => {
         console.log('dragenter');
+        if (this.overlay) {
+          this.overlay.style.zIndex = '20';
+          this.overlay.style.backgroundColor = 'rgba(226, 253, 255, 0.95)';
+        }
         evt.preventDefault();
         evt.stopPropagation();
         this.setAttribute('drag-active', '');
@@ -356,6 +373,10 @@ class MuxUploaderElement extends HTMLElement {
 
       this.addEventListener('dragleave', (evt) => {
         console.log('dragleave');
+        if (this.overlay) {
+          this.overlay.style.zIndex = '-1';
+          this.overlay.style.backgroundColor = '';
+        }
         this.removeAttribute('drag-active');
       });
 


### PR DESCRIPTION
## Description

Adds z-index abundant WIP code for

- Using a full-screen drop zone (currently by default) ➕ 
- Using a full-screen overlay (currently by default) ➕ 
- Accompanying HTML to mimic user placing the file picker button according to their page layout ➕ 

Will probably refactor to make it so that full-screen drop zone and overlay are only active when user passes attribute.

## New To-Dos / Known 
- If you try to drop a file above one of the other interact-able elements i.e. file picker, header, input, it won't work
  - This is because in order to have those items be interact-able while a full-screen drop zone is also interact-able, the former needed to have higher z-index. When hovering over those, drop-zone is not active there 😞 
- Revisit interact-ability of the custom button slot in a full-screen use-case 📝 (z-index?!)
- `stream.new` style overlay is not visible in Safari but full-screen drop still works 🤔 
  - The overlay is implemented with z-index. Will have to check implementation there 🧠 
- Works as expected in Firefox although interestingly the progress bar moves more smoothly 🤔 
- User should not style the `mux-uploader` or its direct container with `position: absolute` 🚫 
  - It will cause the drop zone to be limited to the space that the `mux-uploader` takes up in the Light DOM 👀 

## Work Left
- Make progress bar status (upload percentage, error, completion) be read by screen reader
  - Christian and I are looking into this 🤔 
- Make full-screen progress bar possible in a full-screen use-case 🌈 
- Full-screen error state 🚨 

## Screen Recording
https://user-images.githubusercontent.com/22087604/167538224-14de158b-fff9-4b53-8bf1-5290505fd419.mp4


